### PR TITLE
Update writeAPIBlocking.go

### DIFF
--- a/api/writeAPIBlocking.go
+++ b/api/writeAPIBlocking.go
@@ -119,7 +119,9 @@ func (w *writeAPIBlocking) flush(ctx context.Context) error {
 		body := strings.Join(w.batch, "\n")
 		w.batch = w.batch[:0]
 		b := iwrite.NewBatch(body, w.writeOptions.MaxRetryTime())
-		return w.service.WriteBatch(ctx, b)
+		if err:= w.service.WriteBatch(ctx, b); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
__If you find these changes sufficient, I will reword the commit message and add tests__

Commit https://github.com/influxdata/influxdb-client-go/pull/350/commits/a9c1e378757965a5e5bc81b7b5a3f09cbbdeec97 introduced a bug, where a successful `Flush` returns a non-nil error because the internal function (`w.service.WriteBatch`) returns a concrete pointer and not an `error`.

Closes #

## Proposed Changes

check the concrete type for a `nil` pointer (of type `*http2.Error`) otherwise return an explicit `nil` error.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
